### PR TITLE
feat(creative-writing): add creative writing section with dynamic routes for each writing

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -2,14 +2,16 @@
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import LandingPage from './pages/LandingPage';
 import SpeakerDetail from './pages/SpeakerDetail';
+import CreativeWritingDetail from './pages/CreativeWritingDetail';
 
 function App() {
   return (
     <Router>
-      <div className="min-h-screen bg-black text-white selection:bg-tedx-red selection:text-white font-sans">
+      <div className="min-h-screen bg-black text-white selection:bg-tedx-red selection:text-white font-sans overflow-x-hidden">
         <Routes>
           <Route path="/" element={<LandingPage />} />
           <Route path="/speakers/:slug" element={<SpeakerDetail />} />
+          <Route path="/creative-writing/:slug" element={<CreativeWritingDetail />} />
         </Routes>
       </div>
     </Router>

--- a/app/src/components/About.tsx
+++ b/app/src/components/About.tsx
@@ -4,7 +4,7 @@ import aboutBlurSpotlight from "../assets/about/blur-spotlight.svg"
 const About = () => {
 
   return (
-    <section id="about" className="relative px-6 bg-black text-white">
+    <section id="about" className="relative px-6 bg-black text-white overflow-hidden">
       <div className="relative container py-24 pt-52 max-w-7xl mx-auto text-right">
         <h2 className="font-outfit text-2xl md:text-3xl mb-8 tracking-tighter">About <span className="text-4xl md:text-5xl"><em className="text-tedx-red not-italic">TEDx</em>PUP</span> 2025</h2>
         <div className="flex flex-col gap-4 md:items-end  text-lg leading-relaxed">
@@ -20,7 +20,7 @@ const About = () => {
         </div>
 
         {/* Background Assets */}
-        <img className="absolute bottom-20 right-[46rem]" alt="" src={aboutBlurSpotlight}/>
+        <img className="absolute bottom-20 right-[46rem] hidden md:block" alt="" src={aboutBlurSpotlight}/>
         <img className="absolute bottom-0 invisible md:visible md:-left-48 xl:-left-10 h-full" alt="" src={aboutAccent} />
         <h1
           style={{ WebkitTextStrokeWidth: '1.29px', WebkitTextStrokeColor: 'rgba(255, 255, 255, 0.25)' }}

--- a/app/src/components/CreativeWriting.tsx
+++ b/app/src/components/CreativeWriting.tsx
@@ -1,18 +1,85 @@
+import { Link } from 'react-router-dom';
+import { creativePieces } from '../data/creativeWritingData';
+
 const CreativeWriting = () => {
   return (
-    <section id="creative-writing-entries" className="py-24 px-6 bg-black text-white">
-      <div className="container max-w-7xl mx-auto">
-        <h2 className="text-4xl md:text-5xl font-black mb-12 tracking-tighter text-center">CREATIVE WRITING <span className="text-tedx-red">ENTRIES</span></h2>
-        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
-           {[1, 2, 3].map((i) => (
-             <div key={i} className="bg-gray-900/50 p-8 rounded-xl border border-white/10 hover:border-tedx-red/50 transition-colors">
-                <h3 className="text-xl font-bold mb-4">Entry Title #{i}</h3>
-                <p className="text-gray-400 text-sm mb-6 line-clamp-4">
-                  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-                </p>
-                <button className="text-tedx-red font-medium text-sm hover:underline">Read More →</button>
-             </div>
-           ))}
+    <section id="creative-writing" className="relative py-24 px-6 bg-black text-white overflow-hidden min-h-screen">
+      {/* Subtle Noise Background */}
+      <div className="absolute inset-0 bg-[url('https://grainy-gradients.vercel.app/noise.svg')] opacity-10 pointer-events-none"></div>
+
+      {/* Background Gradient Elements */}
+      <div className="absolute top-0 right-0 w-[500px] h-[500px] bg-tedx-red/20 rounded-full blur-[120px] pointer-events-none"></div>
+      <div className="absolute bottom-0 left-0 w-[500px] h-[500px] bg-blue-900/20 rounded-full blur-[120px] pointer-events-none"></div>
+
+      <div className="relative z-10 container max-w-5xl mx-auto flex flex-col items-center space-y-16">
+        <div className="text-center space-y-4 animate-fade-in-up">
+          <h2 className="text-4xl md:text-5xl font-black tracking-tighter text-white">
+            <span className="text-tedx-red">Creative</span> Writing
+          </h2>
+          <p className="text-gray-400 text-lg max-w-2xl mx-auto">
+             Voices of the community. Stories that evoke, inspire, and reflect.
+          </p>
+        </div>
+
+        <div className="w-full grid gap-8">
+          {creativePieces.map((piece) => (
+            <Link 
+              key={piece.id} 
+              to={`/creative-writing/${piece.slug}`}
+              className="group relative p-6 md:p-8 rounded-2xl border border-white/10 bg-white/5 backdrop-blur-sm transition-all duration-500 ease-in-out hover:border-tedx-red/50 hover:bg-white/[0.07] block"
+            >
+              <div className="flex flex-col md:flex-row gap-6 justify-between items-start">
+                <div className="space-y-4 flex-1">
+                  
+                  {/* Badge */}
+                  <div className="inline-flex items-center px-3 py-1 rounded-full bg-tedx-red/20 border border-tedx-red/30 text-tedx-red text-xs md:text-sm font-bold tracking-wider uppercase">
+                    {piece.category}
+                  </div>
+
+                  {/* Title & Author */}
+                  <div>
+                    <h3 className="text-2xl md:text-3xl font-bold text-white leading-tight group-hover:text-tedx-red transition-colors duration-300">
+                      {piece.title}
+                    </h3>
+                    <p className="text-gray-400 mt-2 font-medium">
+                      By <span className="text-gray-200">{piece.author}</span>
+                    </p>
+                  </div>
+
+                  {/* Content Preview */}
+                  <div className="relative overflow-hidden max-h-24 opacity-80">
+                     <p className="text-gray-300 whitespace-pre-wrap leading-relaxed font-light text-lg line-clamp-3">
+                       {piece.content}
+                     </p>
+                     
+                     <div className="absolute inset-x-0 bottom-0 h-16 bg-gradient-to-t from-black/90 to-transparent pointer-events-none"></div>
+                  </div>
+
+                  {/* Action Button */}
+                  <div 
+                    className="group/btn flex items-center gap-2 text-sm font-semibold text-white tracking-widest uppercase mt-4 group-hover:text-tedx-red transition-colors"
+                  >
+                    Read Full Piece
+                    <svg 
+                      xmlns="http://www.w3.org/2000/svg" 
+                      width="20" 
+                      height="20" 
+                      viewBox="0 0 24 24" 
+                      fill="none" 
+                      stroke="currentColor" 
+                      strokeWidth="2" 
+                      strokeLinecap="round" 
+                      strokeLinejoin="round" 
+                      className="transition-transform duration-300 group-hover:translate-x-1"
+                    >
+                      <path d="M5 12h14"/><path d="m12 5 7 7-7 7"/>
+                    </svg>
+                  </div>
+
+                </div>
+              </div>
+            </Link>
+          ))}
         </div>
       </div>
     </section>

--- a/app/src/components/FAQs.tsx
+++ b/app/src/components/FAQs.tsx
@@ -32,7 +32,7 @@ const FAQs = () => {
               <summary className="flex items-center justify-between p-6 text-2xl lg:text-3xl cursor-pointer hover:bg-white/5 transition-colors list-none">
                 <span className="w-4/5">{faq.question}</span>
                 <span className="bg-white rounded-full p-0.5 transform group-open:rotate-45 transition-transform text-tedx-red text-xl">
-                  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-plus-icon lucide-plus"><path d="M5 12h14" /><path d="M12 5v14" /></svg>
+                  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="lucide lucide-plus-icon lucide-plus"><path d="M5 12h14" /><path d="M12 5v14" /></svg>
                 </span>
               </summary>
               <div className="transition-all p-6 pt-0 text-gray-400 leading-relaxed border-t border-white/5">

--- a/app/src/components/Hero.tsx
+++ b/app/src/components/Hero.tsx
@@ -2,7 +2,7 @@ import Button from './Button';
 
 const Hero = () => {
   return (
-    <section id="hero" className="relative pt-32 px-6 min-h-screen flex flex-col items-center justify-center bg-[radial-gradient(circle_at_top,_var(--tw-gradient-stops))] from-gray-900 via-black to-black">
+    <section id="hero" className="relative pt-32 px-6 min-h-screen flex flex-col items-center justify-center bg-[radial-gradient(circle_at_top,_var(--tw-gradient-stops))] from-gray-900 via-black to-black overflow-hidden">
       <div className="absolute inset-0 bg-[url('https://grainy-gradients.vercel.app/noise.svg')] opacity-20 pointer-events-none"></div>
       
       <div className="z-10 container max-w-7xl text-center space-y-8 animate-fade-in-up">

--- a/app/src/components/XBackground.tsx
+++ b/app/src/components/XBackground.tsx
@@ -1,0 +1,19 @@
+
+const XBackground = () => {
+  return (
+    <div className="absolute inset-0 pointer-events-none overflow-hidden z-0">
+      <img 
+        src="/sponsors/x.webp" 
+        alt="" 
+        className="absolute top-0 right-[-10%] w-[800px] max-w-none opacity-100 mix-blend-screen rotate-12 blur-[1px]"
+      />
+      <img 
+        src="/sponsors/x.webp" 
+        alt="" 
+        className="absolute bottom-[-10%] left-[-10%] w-[600px] opacity-100 mix-blend-screen -rotate-12 blur-[2px]"
+      />
+    </div>
+  );
+};
+
+export default XBackground;

--- a/app/src/data/creativeWritingData.ts
+++ b/app/src/data/creativeWritingData.ts
@@ -1,0 +1,303 @@
+export type Piece = {
+  id: string;
+  slug: string;
+  category: string;
+  title: string;
+  author: string;
+  link: string;
+  content: string;
+};
+
+export const creativePieces: Piece[] = [
+  {
+    id: '1',
+    slug: 'a-shattered-fifty-peso-glass-cost-a-hundred-losses',
+    category: '1st Place & Most Evocative',
+    title: 'A shattered fifty-peso glass cost a hundred losses',
+    author: 'lilacyellowpink',
+    link: 'https://www.reddit.com/r/BosesNgPUP/comments/1pnucmk/a_shattered_fiftypeso_glass_cost_a_hundred_losses/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button',
+    content: `You know how adults used to dismiss your dreams when you were a little kid? I think their lines would go along the lines of “She’s not serious about it. It’s just a phase in her life.” It’s kind of funny that, for some reason, they seem to have this collective talent of breaking dreams and ambitions. 
+
+I was a big dreamer as a kid, and that shouldn’t sound foolish to anyone. A dream can be as big as the sky or small as sand, it doesn’t matter; people dream. But for a family that needs not dreams but practicality, everything comes to nothing. I soon realized that the world has little space for potential—it wants refined talents. They want you to walk back through that door, practice that potential, go back to them, and, if you’re refined enough, that’s when you get accepted. So the dream of a big hearted kid like mine changed its color, shape, depth, and sound multiple times—to the point that I had forgotten that I don't need a dream as big as a star to move forward.
+
+I spent my entire life wondering why my dream is foolish to the adults. I just wanted to be on stage. I wanted to be good enough to do it, yet I was taught to carry one light dream at a time—one that we could afford. 
+
+Truthfully, there’s no place where average people can be seen, so we need to choose whether we want to be great or remain unseen. Unfortunately for me, I had this regretful encounter with a pretty girl where I told her I’d rather be great and seen, and she told me I cannot take it because she had done it before and it was hard. It turned out she had the same dream as mine, and while there might be a girl code for romantic relationships, there’s none for ambitions. People will steal it if they can.
+
+I hope everyone is prepared to accept that almost no one would sincerely tell you to try things. You just have to do it if you want to and don’t if you don’t. That’s the only choice. For me, my dreams cost fifty pesos: fifty for the ride, zero for a used dress, and nothing to walk my way into that audition room. But people had been breaking mine for a long time, and it cost me a hundred lost hope, courage, and chances.
+
+A glass only needs an internal force that exceeds its strength for it to break, and one phrase is forceful enough. It’s more than enough.
+
+But then a glass broken to a hundred shards is not useless. You just need to be brave and let the piece wound your arms and hands a couple of times. You manage and you build it up. When my dreams took the form of writing, I thought I was doing it to cope but I realized I had been doing it to build my glass up. It costs me nothing. Writing this is part of that dream. I have a friend telling me I’m doing great so I know I am seen even as broken glass and that made everything okay.`
+  },
+  {
+    id: '2',
+    slug: 'ate-pa-tarot',
+    category: '2nd Place',
+    title: 'Ate, Pa Tarot!',
+    author: 'ladyelsia',
+    link: 'https://www.reddit.com/r/BosesNgPUP/comments/1pngxk8/ate_pa_tarot/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button',
+    content: `Nang imulat ko ang aking mga mata,
+ramdam ko sa mga kamay mo
+ang ligaya at pangamba.
+
+Ang asiwa ng iyong pagbalasa,
+pintig ng puso mo,
+bulong ng tanong,
+at pagpikit ng mata.
+
+Ako ang tinig na matagal mong inaasam,
+ang sandalan mo sa mundong walang kasiguraduhan.
+
+Sa mga litrato ko nakasaad
+—ang mga kasagutan sa tanong mong walang katapusan.
+
+Oo, ako ang baraha.
+Inaasahan, kinakatakutan, pinagkakasiyahan,
+at para sa iba, hindi pinagkakatiwalaan.
+
+Tinuturing bilang mata ng hinaharap,
+pero sa pagkatao mo ako bumabase at humahanap.
+
+Sa emosyon mong pasikot-sikot,
+mga alinlangan at pagkamausisa,
+tinatanaw ko ang totoo:
+kung ano nga ba ang bumabagabag sa iyo,
+at gaano ito kahalaga sa buhay mo.
+
+Ikaw, bahagyang bumuboses sa sirkumstansya ng iba,
+marahil dahil wala ka noong tiwala
+sa boses na maaaring magtanim ng pagbabago.
+
+Inaral mo ako ng apat na taon
+para ipamahagi sa iyong mga nababasa,
+sa paraang may istruktura,
+walang kapalit, bawat mungkahi’y sinasagot.
+
+At dito, paulit-ulit kong naririnig:
+“Ate, pa-tarot. Ate, pa-tarot. Ate, pa-tarot.”
+
+Sa bawat sabi nila, naririnig ko:
+
+“Natatakot ako. Ako ba ay nasa tamang daan?”
+“Siya na ba ang the one?”
+“Makakapasa kaya ako sa finals?”
+“Yayaman ba ako?”
+“Isang confirmation card nga! Baka mali yan.”
+
+Isang sagot, limang tanong,
+umaalingawngaw habang ako’y unti-unting nauubos—
+hindi lamang sa baraha, kundi sa bigat ng tanong.
+
+Dama ko ang pag-aatubili ng iyong mga kamay,
+mga matang nagmamasid ng reaksyon mo.
+
+Sa tawa mo, umaangat ang pag-asa nila.
+Sa kunot ng noo mo, bumabagsak ang mundo.
+
+Ang pagkuwestiyon mo:
+
+“Sino nga ba ako?
+Para pagbasehan ng katotohanan at desisyon nila?”
+
+Sa boses mong nakaikom ngunit handang magpanatag,
+pinagkaloob mo ang tiwala sa baraha.
+
+Akala nila’y nakaukit na,
+pero ang agos ng hinaharap ay sumasanga.
+
+Kaya nawa’y sa tinig ng pagbasa ko,
+sa kabila ng magulong isipan, may mahinuha:
+
+Na ang huling kard na ihuhugot,
+ang kard na wala sa diksyonaryo ko—
+ay ang kard na gagawin nila, pagkatapos umalis sa mesa mo.`
+  },
+  {
+    id: '3',
+    slug: 'mga-mata-na-di-na-kayang-ipikit-pa',
+    category: '3rd Place',
+    title: 'Mga mata na di na kayang ipikit pa',
+    author: 'GlunGlun',
+    link: 'https://www.reddit.com/r/BosesNgPUP/comments/1pn4pla/mga_mata_na_di_na_kayang_ipikit_pa/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button',
+    content: `Hi! Y'all can call me mallows.
+
+Grabe pala noh? minsan talaga, 'di ko alam kung paano ko nasikmura yung dating ako.
+
+Alam mo yun? Yung tipong estudyante ka na ng kolehiyo, tamang tambay lang sa east wing o kaya sa linear park—pero ang laman ng utak mo, puro sa deadline ng minor subject namin, o kaya sa saan ka gagala pag mag fake f2f ka. Mga nangyayare sa bansa natin? Meh, trabaho na yan ng gobyerno. Basta ako, grumaduate lang at makahanap ng matinong trabaho, okay na.
+
+Dati, nakikita ko yung mga student activists sa campus—yung mga nakikibaka, yung mga may dalang placard sa lagoon. Ang tingin ko sa kanila? Ang ingay. Ang hirap kausap. Sinasabi ko sa sarili ko, "Bakit pa sila nagpapakapagod? Wala namang magbabago. Mag-aral na lang tayo nang tahimik." O kaya, "Sila 'yung mga perennially negative, 'yung mga walang ginawa kundi magreklamo." Parang, stereotypical yung pananaw ko. Wala akong effort intindihin.
+
+Pero... ang daming nagbago. Dito satin, ang hirap i-ignore ng realidad, hindi ba? Lalo na kapag nandoon ka sa gitna ng mga discussion nila. Minsan, papadaan ka lang, tapos maririnig mo yung mga puntong pinaglalaban nila.
+
+Bigla kang titigil, hindi dahil sa galit o inis, kundi dahil... parang may tumamang bato sa ulo mo. Na-realize ko, yung mga issues na di ko pinapansin—pambansang industriyalisasyon, epekto ng inflation, yung mga pang-aapi sa mga magsasaka— eh yun pala, direkta pala yung koneksyon sa buhay ko. Sa tuition na di naman talaga free (kasi may other fees pa), sa magiging minimum wage ko pag grumaduate ako, sa presyo ng bigas na binibili ni Mama.
+
+Yung mga tinatawag kong "maingay" o "reklamador" pala, sila yung mga nagpapaliwanag ng mga bagay na tinatago o hindi na lang pinapansin ng karamihan. Nagsaliksik ako, nagtanong, nakinig. At doon, parang biglang namulat yung mga mata ko. Hindi pala sila basta "galit" lang. May basehan yung galit at pinaglalaban nila. Ang daming facts at historical context na hindi ko lang talaga binibigyan ng pansin dahil masyado akong nakatutok sa sarili ko at sa comfort zone ko.
+
+Ngayon, di ko sinasabing nagbago na ako overnight at kasama na ako agad sa bawat rally. Pero, ang laking pinagbago. Mas nagiging kritikal na ako sa mga nababasa ko. Mas nagtatanong na ako, "Sino ang nakikinabang dito?" o "Ano talaga ang ugat ng problemang ito?" Naiintindihan ko na na ang pagiging iskolar ng bayan—ay hindi lang tungkol sa pag-aaral. Ito ay tungkol sa pagiging aware at pagiging kabahagi ng pagbabago. Yun pala, hindi drama ang pinaglalaban nila; realidad yun. At bilang estudyante, obligasyon kong intindihin ang realidad na 'yan.
+
+Kaya ayun, siguro masasabi kong hindi na ako yung dating ako. Mas stress na ako sa mga problema ng bansa kaysa sa finals namin, pero sa totoo lang, mas panatag na ako. Kasi alam kong nag-iisip na ako.
+
+Ang edukasyon pala ay hindi lang ito "lisensiya" para umangat; ito ang salamin para makita mo ang buong katotohanan. Ngayong namulat na ang aking mga mata, ito na ang bagay hinding-hindi ko na kayang ipikit pa.`
+  },
+  {
+    id: '4',
+    slug: 'the-house-with-no-ceiling',
+    category: 'Best Creative Piece',
+    title: 'The House with No Ceiling',
+    author: 'Carlos Jerico Dela Torre',
+    link: 'https://www.reddit.com/r/BosesNgPUP/comments/1po5lut/the_house_with_no_ceiling/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button',
+    content: `I dreamed of a house with no ceiling,
+Where stars dripped through the rafters
+and moonlight spilled like milk on the floor.
+
+The walls were made of questions,
+not stone.
+Each brick laid with the hands of a boy
+who dared to ask,
+"What if I don’t need to be finished to be whole?"
+
+And the wind,
+it did not knock.
+It entered, freely —
+bringing scent of wild honey,
+old books,
+and names never spoken but deeply known.
+
+In this house,
+there were no thrones.
+Only chairs with soft backs,
+and windows that opened inward.
+
+I sat in the center,
+cross-legged on a rug woven of my own failures and first loves.
+And when the silence creaked,
+I did not fill it.
+I listened.
+
+I listened to the ghost of who I was.
+To the echo of who I am not yet.
+To the gentle, painful truth that I am neither —
+but somehow, gloriously, both.
+
+Outside, the world howled,
+"Be something! Finish! Rise! Reign!"
+
+But inside my chest,
+the quieter voice,
+older than my name,
+whispered:
+"Grow as the forest does — unseen, slow, and sovereign."
+
+Jerico,
+you are the architect of things that cannot be mapped.
+A sculptor of space, not of shape.
+A builder of doors where others see only walls.
+
+Let them misunderstand you.
+Let them fear your stillness.
+Let them try to name you — and fail.
+
+Because some souls are not meant to be decoded.
+They are meant to be experienced.
+Like fire seen from afar.
+Like the lake you can’t measure, but feel pulled toward.
+Like a house with no ceiling —
+letting starlight in,
+and never calling it broken.
+
+When you forget who you are,
+Return here.
+To the quiet floor,
+To the wind-blown questions,
+To the sky above you that never needed to be closed.
+
+You are still becoming.
+And that is the holiest thing I know.`
+  },
+  {
+    id: '5',
+    slug: 'para-sa-mga-invisible',
+    category: 'Most Relatable',
+    title: 'Para sa mga invisible',
+    author: 'Secondborn2007',
+    link: 'https://www.reddit.com/r/BosesNgPUP/comments/1po1eju/para_sa_mga_invisible/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button',
+    content: `What is it that you're most afraid of? Daga? Ipis? Ahas? Commitment? Singko?
+
+For me, nothing compares to the feeling of being unwanted. Alone and desolate. Nothing scares me the most than the thought na i'd be standing in a room na hindi pala ako kailangan. Andun lang ako. Nakatanga. Adrift and purposeless.
+
+Our value in this world is somehow dependent on your contributions. Fame. Excellence. The more you provide, the more the world will give. Long i've learned na, para mapansin ka, dapat magpapansin ka. So ayun siya, nag lock in. I had to struggle my way throughout hierarchies. Friend circles, naging initiative and approachable ako. Acads, i had to burn through every single page just to get through. And that gave me the spark. The one thing na hinahanap nating lahat. The will to live. It gave me— purpose.
+
+But times were changing. I've met all kinds of people. And among them were people na nagturo sa akin ng lesson na "someone will always be better than you; in absolutely everything you do". Meron at merong mas magaling sayo. Since then, things have not been the same. I've developed the habit of comparing myself to those na may nararating na agad sa buhay.
+
+Even though I'm lucky to have a support system na nagsasabi sakin ng things like "stop comparing yourself, everyone has their own struggles". I mean, i know but, i kept telling myself: "given the same circumstance; kung kasing yaman, kasing devoted, kasing active ba nila ako, would i have accomplished those feats as well? junior developer na din ba ako sa isang known company at the age of 17?".
+
+That is where it hits the most.
+
+You know, there is pain in realizing na in a room full of accomplished people; kahit anong effort at achievement pang meron ka, once they've towered over you. Wala na. You'd blend in with everyone else.
+
+Lumala lalo pagdating ko sa PUP. Nadevelop lalo yung imposter syndrome. Especially when i have friends na nakapasok sa UP. The big dream. The final boss. yet here i am, looking at them from a distance. I find it so hard having to process the feeling na your friends are out there experiencing life at it's most raw and blunt face. While im out here, writing my inconsequential thoughts to myself. And probably to you, reader. At this point kung talagang nagbabasa ka pa, I'm gonna assume na nakakarelate ka. If so, then I want you to realize na you can find solace in here because i know the feeling. Trust me.
+
+But if you're gonna ask me how to actually solve it, I'm afraid you're after the wrong guy. The reason being, I have not, since then, been able to make peace with this thought. I figured, who would prefer the lesser options when obviously, you've been given the best choices? In a room full of accomplished people, who would settle for less?
+
+That, to me, is the hardest pill i could never swallow. Though, what's important is, you're here, because showing up is the catalyst for change. At this very moment. If we let the shadows of doubt loom over us, then we lose the precious privilege, that is, to live an unpredictable life. To succumb to self deprecation, is to fall victim to the inviting trance of hopelessness and mediocrity. And enticing as it may sound, I just know you are worth more than that. Your value should not be measured in its weight in gold, but by existence alone. Whoever you are, i wish only the best for you.`
+  },
+  {
+    id: '6',
+    slug: 'one-day-i-will-grow-wings',
+    category: 'Best Personal Reflection',
+    title: 'One day I will grow wings.',
+    author: 'Left_Chicken_9900',
+    link: 'https://www.reddit.com/r/BosesNgPUP/comments/1pnzx05/one_day_i_will_grow_wings/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button',
+    content: `While staying home for a while in my hometown, I am greeted by my old clothes.
+
+I thought bringing my usual clothing from my dorm was such a drag since I was only visiting for a few days at home since there were no onsite classes for the week. With only my laptop and medication with me, I greeted my then surprised family. Ironically, I was more shocked when I scanned our home as I entered.
+
+My old desk changed. My pinboard that I spent my defining years curating was changed, replaced by family pictures. Without my consent, I was bombarded by old memories that I haven’t revisited since leaving. Even a photo that I haven’t seen for so long—my graduation picture when I was in 6th grade—was there.
+
+Whilst upset, I just greeted my mother normally. At the end of the day I just wanted to unwind after being in commute for 3 hours, so I showered and headed to my room to get dressed. I grabbed whichever clothing I saw inside my drawer—a graphic tee with the bold word “Tokyo,” which I’ve had since I was in 7th grade—and went to our living room.
+
+“That doesn’t fit you,” my mother abruptly told me whilst we were eating dinner.
+
+Was it my short haircut, which she insisted during a video call was a bad idea? Or was it the new eyebrow piercing that I got on a whim? Maybe she finally came to and agreed that the shirt that I’m wearing (as well as my other clothes that I’ve left) should be disposed of after all.
+
+I, till this day, don’t know what she was referring to.
+
+My girlfriend visited me at my home whilst I was staying in Cavite then. Whilst we talked normally, she made some passing comments from time to time about how my clothing didn’t really fit me anymore.
+
+Other than the obvious weird picture of a transmasc person wearing girl clothes, I also had filled out the sleeves of my clothing as my muscle distribution changed.
+
+With my newfound independence living alone, I was able to fully reflect on how I see myself and how I want people to perceive me. I presented more masculinely, and I even started HRT.
+
+When they say that a person regresses when they come visit their old house, it isn’t an understatement. The dysphoria I left at home came back to me all at once, seemingly harder than ever due to me finally experiencing my true authentic self elsewhere.
+
+I felt like I was 5 years old again and was being actively forced to wear dresses and keep my hair below my shoulders.
+
+I can never escape this feeling when I’m in my hometown, because whilst I resent the feeling of judgement, I crave the affection that I don’t receive when I’m in the cities.
+
+I celebrate my 1 year on testosterone this April 11, and I still feel shame when coming home. Even then, I’d still like to think that I’m winning regardless.
+
+Thanks to LGBTQIA+ NGOs like LoveYourself, I was able to transition safely even in an administration where SOGIE rights are still controversial and continuously dismissed. Right now where trans people continue to be hatecrime’d without any justice, the status quo needs to be challenged especially.
+
+Whilst difficult, I know for a fact that I will be okay. I want to live in a distant future where I am able to see, breathe, feel, smell, and hear freely.`
+  },
+  {
+    id: '7',
+    slug: 'the-unsilent-syllabus-my-pointe-shoes',
+    category: 'Best Symbolic Writing',
+    title: 'The Unsilent Syllabus: My Pointe Shoes',
+    author: 'Acceptable_Sea_4959',
+    link: 'https://www.reddit.com/r/BosesNgPUP/comments/1pnd4hn/the_unsilent_syllabus_my_pointe_shoes/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button',
+    content: `The DOST Grant is the gilded chain I wear, A heavy honor that demands a prescribed silence. My education is the tool of the State, designed to build stability, not to articulate the fluidity of the soul. I am a Psychology student, charting the neural pathways of change, but the only revolution I truly crave is the one in my own axis.
+
+My family’s love is a soft, supportive Acoustic Dampener; They believe in me, but they must dampen the impractical sound of the arts. Their sacrifice provides the foundation, but not the freedom. My father's "Sayang" is a quiet lament, not a shout of shame. The silent pressure to deliver return on investment stifles the voice that wants to sing through the feet.
+
+I stand in the public university, a vessel of logic and theory. I watch the foreign masters, inheriting the Lexicon of Air, A flawless vocabulary built on wealth and time. My voice, my true art, is relegated to the marginalia of my life: Stolen, crude, Taglish steps against their perfect French. I envy their knowledge, for knowledge gives one the right to be heard. I feel like a changemaker without a megaphone.
+
+My dorm room is my booth, my private voting station. I use the geometry of my body to make my silent protest. My back pressed against the wall, I am performing the Choreography of Resistance. The floor is cold; I am practicing the Economics of Effort— No wasted movement, only focused, desperate lift. I am running on the fumes of instant coffee and raw will to push and pull every muscle in my body.
+
+I hold the imaginary shoes— They are not satin, but a shimmering, impossible petition for value. The pointe shoes I wasn't able to wear are my Unspoken Thesis— A public indictment of a system that deems art a luxury, not the necessary voice of a developing nation. They are the ghost of perfection, demanding a seat at the table.
+
+But watch me, in the final hour before the campus lights shut down. I take the tendu I stole— Infused with the tired, disciplined energy of the scholar. My body, untrained, performs a Dichotomy: grounded in duty, lifted by defiance. This is not a dance for the theater; it is a Statement. I am the scholar who whispers his art, the voice that sparks change by refusing to let the mandatory silence erase the truth that creativity is not the opposite of security, but its deepest reason.`
+  }
+];

--- a/app/src/pages/CreativeWritingDetail.tsx
+++ b/app/src/pages/CreativeWritingDetail.tsx
@@ -1,0 +1,92 @@
+import { useParams, useNavigate, Link } from 'react-router-dom';
+import Navbar from '../components/Navbar';
+import { creativePieces } from '../data/creativeWritingData';
+import { useEffect } from 'react';
+
+import XBackground from '../components/XBackground';
+
+const CreativeWritingDetail = () => {
+  const { slug } = useParams();
+  const navigate = useNavigate();
+  const piece = creativePieces.find(p => p.slug === slug);
+
+  // Scroll to top on mount
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
+
+  if (!piece) {
+    return (
+      <div className="min-h-screen bg-black text-white selection:bg-tedx-red selection:text-white font-sans flex flex-col">
+        <Navbar />
+        <div className="flex-1 flex flex-col items-center justify-center p-6 text-center">
+            <h1 className="text-4xl font-bold mb-4">Piece Not Found</h1>
+            <Link to="/" className="text-tedx-red hover:underline">← Return Home</Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-black text-white selection:bg-tedx-red selection:text-white font-sans flex flex-col">
+      <Navbar />
+      
+      <main className="flex-1 relative overflow-hidden">
+         <XBackground />
+         {/* Background Elements */}
+         <div className="absolute top-0 right-0 w-[500px] h-[500px] bg-tedx-red/10 rounded-full blur-[120px] pointer-events-none"></div>
+         <div className="absolute bottom-0 left-0 w-[500px] h-[500px] bg-blue-900/10 rounded-full blur-[120px] pointer-events-none"></div>
+
+         <div className="relative z-10 container max-w-4xl mx-auto px-6 py-32 flex flex-col gap-8">
+           
+           <button onClick={() => navigate(-1)} className="inline-flex items-center gap-2 px-4 py-2 rounded-full border border-white/20 text-sm font-medium text-gray-300 hover:text-white hover:border-tedx-red hover:bg-tedx-red/10 transition-all duration-300 group self-start backdrop-blur-sm cursor-pointer">
+             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="group-hover:-translate-x-1 transition-transform duration-300">
+               <path d="M19 12H5"/>
+               <path d="m12 19-7-7 7-7"/>
+             </svg>
+             Back
+           </button>
+
+           <header className="space-y-6 border-b border-white/10 pb-8">
+             <div className="inline-flex items-center px-3 py-1 rounded-full bg-tedx-red/20 border border-tedx-red/30 text-tedx-red text-sm font-bold tracking-wider uppercase">
+                {piece.category}
+             </div>
+             
+             <h1 className="text-4xl md:text-6xl font-black tracking-tighter leading-tight text-white">
+               {piece.title}
+             </h1>
+
+             <div className="flex flex-col md:flex-row md:items-center gap-4 text-gray-400">
+                <p className="text-lg">
+                   By <span className="text-white font-semibold">{piece.author}</span>
+                </p>
+                {piece.link && (
+                    <>
+                        <span className="hidden md:inline text-gray-700">•</span>
+                        <a 
+                          href={piece.link} 
+                          target="_blank" 
+                          rel="noopener noreferrer" 
+                          className="text-sm text-tedx-red/80 hover:text-tedx-red hover:underline flex items-center gap-1 w-fit"
+                        >
+                          View Original Submission 
+                          <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+                        </a>
+                    </>
+                )}
+             </div>
+           </header>
+           
+           <article className="prose prose-invert prose-lg max-w-none">
+             <div className="whitespace-pre-wrap leading-relaxed font-light text-gray-300">
+               {piece.content}
+             </div>
+           </article>
+
+         </div>
+      </main>
+    </div>
+  );
+};
+
+export default CreativeWritingDetail;


### PR DESCRIPTION
<img width="1382" height="888" alt="image" src="https://github.com/user-attachments/assets/275ba895-9739-47f8-9b28-53d3316b8f5f" />
<img width="1370" height="860" alt="image" src="https://github.com/user-attachments/assets/3aa2e15f-bb0d-4c6e-8c4b-24d5436ce6f1" />
<img width="506" height="871" alt="image" src="https://github.com/user-attachments/assets/3860b274-3c51-4203-acfe-59fc7f68222e" />
<img width="456" height="847" alt="image" src="https://github.com/user-attachments/assets/73bd11bb-4b3c-4058-8698-3feb3a0e4f07" />
