### PR TITLE
feat(navbar): collapse to hamburger menu on tablet devices

### DIFF
--- a/app/src/components/features/FAQs.tsx
+++ b/app/src/components/features/FAQs.tsx
@@ -5,7 +5,9 @@ const FAQs = () => {
   return (
     <section id="faqs" className="py-24 px-6 bg-black text-white border-t border-white/10">
       <div className="container lg:flex justify-between max-w-7xl mx-auto">
-        <h2 className="text-4xl md:text-5xl font-medium font-outfit mb-12 "><em className="not-italic text-tedx-red">Frequently</em> Asked Questions</h2>
+        <h1 className="text-4xl md:text-5xl font-medium font-outfit mb-12 ">
+          <em className="not-italic text-tedx-red font-bold">Frequently</em> <strong>Asked Questions</strong>
+        </h1>
         <div className="max-w-3xl mx-auto space-y-4">
           {faqData.map((faq: FAQ, id: number) => (
             <details key={id} className="max-w-3xl group border-b-2 border-white/10 overflow-hidden">
@@ -15,7 +17,7 @@ const FAQs = () => {
                   <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="lucide lucide-plus-icon lucide-plus"><path d="M5 12h14" /><path d="M12 5v14" /></svg>
                 </span>
               </summary>
-              <div className="transition-all p-6 pt-0 text-gray-400 leading-relaxed border-t border-white/5">
+              <div className="transition-all p-6 pt-0 text-gray-400 leading-relaxed">
                 {faq.answer}
                 {faq.hasButton && (
                   <a 

--- a/app/src/components/features/FAQs.tsx
+++ b/app/src/components/features/FAQs.tsx
@@ -10,7 +10,7 @@ const FAQs = () => {
         </h1>
         <div className="max-w-3xl mx-auto space-y-4">
           {faqData.map((faq: FAQ, id: number) => (
-            <details key={id} className="max-w-3xl group border-b-2 border-white/10 overflow-hidden">
+            <details key={id} className="max-w-xl group border-b-2 border-white/10 overflow-hidden">
               <summary className="flex items-center justify-between p-6 text-2xl lg:text-3xl cursor-pointer hover:bg-white/5 transition-colors list-none">
                 <span className="w-4/5">{faq.question}</span>
                 <span className="bg-white rounded-full p-0.5 transform group-open:rotate-45 transition-transform text-tedx-red text-xl">

--- a/app/src/components/features/FAQs.tsx
+++ b/app/src/components/features/FAQs.tsx
@@ -4,27 +4,27 @@ const FAQs = () => {
 
   return (
     <section id="faqs" className="py-24 px-6 bg-black text-white border-t border-white/10">
-      <div className="container lg:flex justify-between max-w-7xl mx-auto">
-        <h1 className="text-4xl md:text-5xl font-medium font-outfit mb-12 ">
+      <div className="container lg:flex justify-between gap-8 max-w-7xl mx-auto">
+        <h1 className="text-4xl md:text-5xl lg:text-5xl font-medium font-outfit mb-12 lg:mb-0 lg:w-2/5 shrink-0">
           <em className="not-italic text-tedx-red font-bold">Frequently</em> <strong>Asked Questions</strong>
         </h1>
-        <div className="max-w-3xl mx-auto space-y-4">
+        <div className="w-full lg:w-3/5 space-y-4">
           {faqData.map((faq: FAQ, id: number) => (
-            <details key={id} className="max-w-xl group border-b-2 border-white/10 overflow-hidden">
-              <summary className="flex items-center justify-between p-6 text-2xl lg:text-3xl cursor-pointer hover:bg-white/5 transition-colors list-none">
-                <span className="w-4/5">{faq.question}</span>
+            <details key={id} className="group border-b-2 border-white/10 overflow-hidden">
+              <summary className="flex items-center justify-between p-4 md:p-6 text-lg md:text-2xl lg:text-3xl cursor-pointer hover:bg-white/5 transition-colors list-none">
+                <span className="w-4/5 pr-4">{faq.question}</span>
                 <span className="bg-white rounded-full p-0.5 transform group-open:rotate-45 transition-transform text-tedx-red text-xl">
                   <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="lucide lucide-plus-icon lucide-plus"><path d="M5 12h14" /><path d="M12 5v14" /></svg>
                 </span>
               </summary>
-              <div className="transition-all p-6 pt-0 text-gray-400 leading-relaxed">
+              <div className="transition-all p-4 md:p-6 pt-0 text-sm md:text-base text-gray-400 leading-relaxed">
                 {faq.answer}
                 {faq.hasButton && (
                   <a 
                     href={faq.buttonLink} 
                     target="_blank" 
                     rel="noopener noreferrer"
-                    className="block mt-4 px-6 py-3 bg-tedx-red text-white font-medium rounded-lg hover:bg-tedx-red/90 transition-colors w-fit"
+                    className="block mt-4 px-4 md:px-6 py-2 md:py-3 text-sm md:text-base bg-tedx-red text-white font-medium rounded-lg hover:bg-tedx-red/90 transition-colors w-fit"
                   >
                     {faq.buttonText}
                   </a>

--- a/app/src/components/features/Navbar.tsx
+++ b/app/src/components/features/Navbar.tsx
@@ -13,12 +13,12 @@ const Navbar = () => {
       <nav className="fixed top-0 left-0 w-full z-50 px-8 py-6 bg-black/60 backdrop-blur-2xl shadow-[0_4px_4px_0_rgba(0,0,0,0.08)]">
         <div className="container max-w-7xl mx-auto flex items-center justify-between">
           {/* Logo */}
-          <img src="/logo-white.webp" alt="TEDxPUP" className="h-12 md:h-14 w-auto object-contain -ml-3" />
+          <img src="/logo-white.webp" alt="TEDxPUP" className="h-12 lg:h-14 w-auto object-contain -ml-3" />
 
           {/* Mobile Menu Button */}
           <button 
             onClick={toggleMenu}
-            className="md:hidden relative z-50 p-2 text-white hover:text-tedx-red transition-colors focus:outline-none"
+            className="lg:hidden relative z-50 p-2 text-white hover:text-tedx-red transition-colors focus:outline-none"
             aria-label="Toggle menu"
           >
             <div className="w-6 h-5 flex flex-col justify-between">
@@ -29,7 +29,7 @@ const Navbar = () => {
           </button>
 
           {/* Desktop Navigation */}
-          <div className="hidden md:flex items-center gap-8">
+          <div className="hidden lg:flex items-center gap-8">
             {navLinks.map((link) => (
               <a 
                 key={link} 
@@ -48,7 +48,7 @@ const Navbar = () => {
       </nav>
 
       {/* Mobile Navigation Overlay */}
-      <div className={`fixed inset-0 bg-black z-40 flex flex-col pt-24 pb-8 overflow-y-auto duration-500 md:hidden ${isOpen ? 'opacity-100 visible' : 'opacity-0 invisible pointer-events-none'}`}>
+      <div className={`fixed inset-0 bg-black z-40 flex flex-col pt-24 pb-8 overflow-y-auto duration-500 lg:hidden ${isOpen ? 'opacity-100 visible' : 'opacity-0 invisible pointer-events-none'}`}>
         <div className="flex flex-col items-center space-y-6 px-6 w-full min-h-0">
           {navLinks.map((link) => (
             <a 


### PR DESCRIPTION
Change responsive breakpoint from md (768px) to lg (1024px) to ensure navbar collapses into hamburger menu on tablets like iPad. This improves usability and prevents layout issues on smaller screen sizes.

<img width="658" height="707" alt="image" src="https://github.com/user-attachments/assets/3979f1a2-71b2-4036-b782-784bf38ac049" />
<img width="494" height="649" alt="image" src="https://github.com/user-attachments/assets/138d380e-6796-4e9f-87bf-595a7c65b71c" />
