### PR TITLE
fix: prevent white flash when scrolling

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -4,10 +4,11 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="dark" />
     <title>TEDxPUP</title>
     <script src="https://js.tito.io/v2" async></script>
   </head>
-  <body>
+  <body style="background-color: #000000; color: #ffffff">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/app/src/components/ui/ScrollReveal.tsx
+++ b/app/src/components/ui/ScrollReveal.tsx
@@ -1,56 +1,57 @@
 import { useEffect, useRef, useState, type ReactNode } from "react";
 
 interface ScrollRevealProps {
-    children: ReactNode;
-    className?: string;
-    threshold?: number;
-    delay?: string; // e.g., "0s", "0.2s"
+  children: ReactNode;
+  className?: string;
+  threshold?: number;
+  delay?: string; // e.g., "0s", "0.2s"
 }
 
 const ScrollReveal = ({
-    children,
-    className = "",
-    threshold = 0,
-    delay = "0s",
+  children,
+  className = "",
+  threshold = 0,
+  delay = "0s",
 }: ScrollRevealProps) => {
-    const [isVisible, setIsVisible] = useState(false);
-    const ref = useRef<HTMLDivElement>(null);
+  const [isVisible, setIsVisible] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
 
-    useEffect(() => {
-        const observer = new IntersectionObserver(
-            ([entry]) => {
-                if (entry.isIntersecting) {
-                    setIsVisible(true);
-                    observer.unobserve(entry.target);
-                }
-            },
-            {
-                threshold,
-                rootMargin: "0px 0px 50px 0px",
-            }
-        );
-
-        if (ref.current) {
-            observer.observe(ref.current);
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true);
+          observer.unobserve(entry.target);
         }
-
-        return () => {
-            if (ref.current) {
-                observer.unobserve(ref.current);
-            }
-        };
-    }, [threshold]);
-
-    return (
-        <div
-            ref={ref}
-            className={`transition-all duration-400 ease-out transform ${isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"
-                } ${className}`}
-            style={{ transitionDelay: delay }}
-        >
-            {children}
-        </div>
+      },
+      {
+        threshold,
+        rootMargin: "0px 0px 200px 0px",
+      },
     );
+
+    if (ref.current) {
+      observer.observe(ref.current);
+    }
+
+    return () => {
+      if (ref.current) {
+        observer.unobserve(ref.current);
+      }
+    };
+  }, [threshold]);
+
+  return (
+    <div
+      ref={ref}
+      className={`transition-all duration-500 ease-out transform will-change-transform ${
+        isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-8"
+      } ${className}`}
+      style={{ transitionDelay: delay }}
+    >
+      {children}
+    </div>
+  );
 };
 
 export default ScrollReveal;

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -1,20 +1,21 @@
 @font-face {
-  font-family: 'Helvetica';
-  src: url('./assets/fonts/Helvetica.ttf') format('truetype');
+  font-family: "Helvetica";
+  src: url("./assets/fonts/Helvetica.ttf") format("truetype");
   font-weight: 400;
   font-style: normal;
 }
 
 @font-face {
-  font-family: 'Helvetica';
-  src: url('./assets/fonts/Helvetica-Bold.ttf') format('truetype');
+  font-family: "Helvetica";
+  src: url("./assets/fonts/Helvetica-Bold.ttf") format("truetype");
   font-weight: 700;
   font-style: normal;
 }
 
 @font-face {
-  font-family: 'Helvetica';
-  src: url('./assets/fonts/helvetica-light-587ebe5a59211.ttf') format('truetype');
+  font-family: "Helvetica";
+  src: url("./assets/fonts/helvetica-light-587ebe5a59211.ttf")
+    format("truetype");
   font-weight: 400;
   font-style: normal;
 }
@@ -23,9 +24,11 @@
 @tailwind components;
 @tailwind utilities;
 
-html, body {
+html,
+body {
   background-color: #000000;
   color: #ffffff;
+  color-scheme: dark;
   scroll-behavior: smooth;
   margin: 0;
   padding: 0;
@@ -48,7 +51,7 @@ html, body {
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background-color: #9CA3AF;
+  background-color: #9ca3af;
 }
 
 /* --- THE NEW TRIANGLE BUTTONS --- */
@@ -93,15 +96,14 @@ html, body {
 /* Active (Clicked) State - Keeps it gray or you can make it darker */
 ::-webkit-scrollbar-button:vertical:decrement:active,
 ::-webkit-scrollbar-button:vertical:increment:active {
-  background-color: #9CA3AF; /* Slight background highlight when clicking */
+  background-color: #9ca3af; /* Slight background highlight when clicking */
 }
-
 
 /* --- 2. Firefox Support Block --- */
 /* This ensures Firefox behaves normally and doesn't break Edge */
 @supports not selector(::-webkit-scrollbar) {
   html {
-    scrollbar-width: thin; 
+    scrollbar-width: thin;
     scrollbar-color: #e62b1f #000000;
   }
 }


### PR DESCRIPTION
This pull request focuses on improving the application's dark mode support and refining UI transitions. The main changes include enforcing a dark color scheme across the app, enhancing the scroll reveal animation, and making minor code formatting improvements.

**Dark mode and color scheme improvements:**
- Added `<meta name="color-scheme" content="dark" />` to `app/index.html` and set the body background and text color to enforce dark mode styling.
- Updated `html, body` styles in `app/src/index.css` to include `color-scheme: dark;` and set background and text colors to match the dark theme.

**UI and animation enhancements:**
- Increased the `rootMargin` in the `ScrollReveal` component for earlier reveal and updated the animation for a smoother, more pronounced effect, including a longer transition duration and greater vertical movement. [[1]](diffhunk://#diff-64ddb71b74819d920ecc6b09d3763b626ccbb126fc98dd42015a9a2adad9caa7L29-R30) [[2]](diffhunk://#diff-64ddb71b74819d920ecc6b09d3763b626ccbb126fc98dd42015a9a2adad9caa7L47-R48)

**Code and style consistency:**
- Standardized font-face declarations in `app/src/index.css` to use double quotes and consistent formatting.
- Updated hex color formatting for scrollbar elements to use lowercase for consistency. [[1]](diffhunk://#diff-0e8cfeba27f9bd404b3c20c24f4b8dbc1d30afcccd9fa54ddb16dafb69e4e252L51-R54) [[2]](diffhunk://#diff-0e8cfeba27f9bd404b3c20c24f4b8dbc1d30afcccd9fa54ddb16dafb69e4e252L96-L99)