### PR TITLE
feat(buttons): removal of get tickets and secure seat buttons

### DIFF
--- a/app/src/components/features/CTA.tsx
+++ b/app/src/components/features/CTA.tsx
@@ -1,4 +1,5 @@
-import Button from "../ui/Button";
+// import Button from "../ui/Button";
+import { FaFacebook, FaInstagram, FaTiktok } from "react-icons/fa";
 
 const CTA = () => {
   return (
@@ -7,18 +8,51 @@ const CTA = () => {
       <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[600px] h-[600px] bg-tedx-red/20 blur-[100px] rounded-full pointer-events-none" />
 
       <div className="container max-w-4xl mx-auto px-6 relative z-10 text-center space-y-8">
-        <h2 className="text-4xl md:text-6xl font-black text-white tracking-tighter uppercase font-outfit drop-shadow-xl">
-          Ready to Spark <span className="text-tedx-red">Change?</span>
+        <h2 className="text-3xl sm:text-4xl md:text-5xl font-black text-white tracking-tighter uppercase font-outfit drop-shadow-xl whitespace-nowrap">
+          NO UPCOMING EVENTS<span className="text-tedx-red">…FOR NOW</span>
         </h2>
 
-        <p className="text-lg md:text-2xl text-gray-200 font-light max-w-2xl mx-auto leading-relaxed">
-          Join us on{" "}
-          <span className="text-white font-bold">February 13, 2026</span> at{" "}
-          <span className="text-white font-bold">The Astbury</span> for an
-          unforgettable day of ideas, inspiration, and connection.
-        </p>
+        <div className="space-y-4 px-4 w-full">
+          <p className="text-base md:text-xl text-gray-200 font-light max-w-2xl mx-auto leading-relaxed">
+            There are no events scheduled at the moment — but something exciting is always in the works.
+          </p>
+          <p className="text-base md:text-xl text-gray-200 font-light max-w-2xl mx-auto leading-relaxed">
+            Stay connected and be the first to know what's coming next.
+          </p>
+        </div>
 
-        <div className="pt-8">
+        {/* Social Media Links */}
+        <div className="pt-1 flex justify-center items-center gap-6">
+          <a
+            href="https://www.facebook.com/TEDxPUP"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-white hover:text-tedx-red transition-colors duration-300"
+            aria-label="TEDxPUP Facebook"
+          >
+            <FaFacebook size={32} />
+          </a>
+          <a
+            href="https://www.instagram.com/tedxpup/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-white hover:text-tedx-red transition-colors duration-300"
+            aria-label="TEDxPUP Instagram"
+          >
+            <FaInstagram size={32} />
+          </a>
+          <a
+            href="https://www.tiktok.com/@tedxpup"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-white hover:text-tedx-red transition-colors duration-300"
+            aria-label="TEDxPUP TikTok"
+          >
+            <FaTiktok size={32} />
+          </a>
+        </div>
+
+        {/* <div className="pt-8">
           <Button
             href="https://ti.to/tedxpup/tedxpup2026"
             target="_blank"
@@ -31,7 +65,7 @@ const CTA = () => {
 
         <p className="text-sm text-gray-400 mt-6">
           Limited seats available. Don't miss out!
-        </p>
+        </p> */}
       </div>
     </section>
   );

--- a/app/src/components/features/Hero.tsx
+++ b/app/src/components/features/Hero.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import Button from "../ui/Button";
+// import Button from "../ui/Button";
 import { FiClock, FiMapPin } from "react-icons/fi";
 import { motion } from "framer-motion";
 
@@ -145,7 +145,7 @@ const Hero = () => {
             </div>
           </div>
 
-          <div className="flex flex-col items-center gap-3 w-full">
+          {/* <div className="flex flex-col items-center gap-3 w-full">
             <Button
               href="https://ti.to/tedxpup/tedxpup2026"
               target="_blank"
@@ -155,7 +155,7 @@ const Hero = () => {
             >
               GET TICKETS
             </Button>
-          </div>
+          </div> */}
         </div>
       </div>
     </section>

--- a/app/src/components/features/Navbar.tsx
+++ b/app/src/components/features/Navbar.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
-import Button from "../ui/Button";
+// import Button from "../ui/Button";
 
 const Navbar = () => {
   const [isOpen, setIsOpen] = useState(false);
@@ -131,8 +131,8 @@ const Navbar = () => {
             })}
           </div>
 
-          {/* CTA Button (Right) */}
-          <div className="hidden lg:block">
+          {/* CTA Button (Right) - Hidden as event ended */}
+          {/* <div className="hidden lg:block">
             <Button
               href="https://ti.to/tedxpup/tedxpup2026"
               target="_blank"
@@ -141,7 +141,7 @@ const Navbar = () => {
             >
               Get Tickets
             </Button>
-          </div>
+          </div> */}
         </div>
       </nav>
 
@@ -160,7 +160,7 @@ const Navbar = () => {
               {link}
             </a>
           ))}
-          <div className="pt-4 w-full max-w-xs mx-auto">
+          {/* <div className="pt-4 w-full max-w-xs mx-auto">
             <Button
               href="https://ti.to/tedxpup/tedxpup2026"
               target="_blank"
@@ -170,7 +170,7 @@ const Navbar = () => {
             >
               Get Tickets
             </Button>
-          </div>
+          </div> */}
         </div>
       </div>
     </>


### PR DESCRIPTION
Removed "Get Tickets" and "Secure Seat" buttons since the event has ended. The code is commented out rather than deleted for future reference.

<img width="1896" height="97" alt="image" src="https://github.com/user-attachments/assets/cecf2d95-07ae-466b-a02c-52256d86ba44" />
<img width="1893" height="548" alt="image" src="https://github.com/user-attachments/assets/f7d6caf2-9c41-456d-b082-e6ea16754539" />
