### PR TITLE
refactor(section): hide event location and program section for post-event-state

### DIFF
--- a/app/src/components/features/Footer.tsx
+++ b/app/src/components/features/Footer.tsx
@@ -3,14 +3,11 @@ import { useEffect, type FC } from 'react';
 import { FaFacebook, FaInstagram, FaTiktok } from 'react-icons/fa6';
 import { SiGmail } from 'react-icons/si';
 
-const NAV_LINKS = [
+const footerLinks = [
     { label: 'About', href: '#about' },
-    { label: 'Event Location', href: '#location' },
     { label: 'Speakers', href: '#speakers' },
-    { label: 'Program', href: '#program' },
-    { label: 'Creative Writing Entries', href: '#creative-writing' },
-    { label: 'Sponsors & Partners', href: '#sponsors-partners' },
-    { label: 'FAQs', href: '#faqs' },
+    { label: 'Creative Writing', href: '#creative-writing' },
+    { label: 'FAQs', href: '#faqs' }
 ];
 
 const Footer: FC = () => {
@@ -61,7 +58,7 @@ const Footer: FC = () => {
                     <div className="flex flex-col space-y-4">
                         <h3 className="text-white font-semibold text-base mb-2">NAVIGATION</h3>
                         <ul className="space-y-2 text-sm text-gray-400">
-                            {NAV_LINKS.map((link) => (
+                            {footerLinks.map((link) => (
                                 <li key={link.label}>
                                     <a href={link.href} className="hover:text-tedx-red transition-colors">
                                         {link.label}

--- a/app/src/components/features/Navbar.tsx
+++ b/app/src/components/features/Navbar.tsx
@@ -18,12 +18,15 @@ const Navbar = () => {
     }
   };
 
-  const navLinks = ["ABOUT", "SPEAKERS", "PROGRAM", "CREATIVE WRITING ENTRIES", "FAQs"];
+  const navLinks = ["ABOUT", "SPEAKERS", "CREATIVE WRITING ENTRIES", "SPONSORS & PARTNERS", "FAQs"];
 
   // Map display names to section IDs
   const getLinkId = (link: string) => {
     if (link === "CREATIVE WRITING ENTRIES") {
       return "creative-writing";
+    }
+    if (link === "SPONSORS & PARTNERS") {
+      return "sponsors-partners";
     }
     return link.toLowerCase().replace(/ /g, "-");
   };
@@ -113,7 +116,7 @@ const Navbar = () => {
           </button>
 
           {/* Desktop Navigation (Centered) */}
-          <div className="hidden lg:flex items-center gap-8 absolute left-1/2 -translate-x-1/2">
+          <div className="hidden lg:flex items-center gap-4 xl:gap-8 absolute left-1/2 -translate-x-1/2 w-max">
             {navLinks.map((link) => {
               const linkId = getLinkId(link);
               return (

--- a/app/src/pages/LandingPage.tsx
+++ b/app/src/pages/LandingPage.tsx
@@ -1,9 +1,9 @@
 import Navbar from "../components/features/Navbar";
 import Hero from "../components/features/Hero";
 import About from "../components/features/About";
-import Location from "../components/features/Location";
+// import Location from "../components/features/Location";
 import Speakers from "../components/features/Speakers";
-import ProgramFlow from "../components/features/ProgramFlow";
+// import ProgramFlow from "../components/features/ProgramFlow";
 import CreativeWriting from "../components/features/CreativeWriting";
 import Partners from "../components/features/Partners";
 import FAQs from "../components/features/FAQs";
@@ -33,9 +33,9 @@ const LandingPage = () => {
       <main className="flex flex-col">
         <Hero />
         <About />
-        <Location />
+        {/* <Location /> */}
         <Speakers />
-        <ProgramFlow />
+        {/* <ProgramFlow /> */}
         <CreativeWriting />
         <Partners />
         <FAQs />


### PR DESCRIPTION
Commented out the Event Location and Program sections since the event has ended. Removed the Program link from the navbar and added "Sponsors & Partners."

<img width="1897" height="103" alt="image" src="https://github.com/user-attachments/assets/95c43455-a49c-4554-a6ed-17c299dc1ffb" />
